### PR TITLE
AvalonDock fixed crash when shrinking auto-sized panel

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutGridControl.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutGridControl.cs
@@ -386,6 +386,10 @@ namespace Xceed.Wpf.AvalonDock.Controls
                 {
                     prevChildModel.DockWidth = new GridLength(prevChildModel.DockWidth.Value * (prevChildActualSize.Width + delta) / prevChildActualSize.Width, GridUnitType.Star);
                 }
+                else if (prevChildModel.DockWidth.IsAuto)
+                {
+                    prevChildModel.DockWidth = new GridLength(prevChildActualSize.Width + delta, GridUnitType.Pixel);
+                }
                 else
                 {
                     prevChildModel.DockWidth = new GridLength(prevChildModel.DockWidth.Value + delta, GridUnitType.Pixel);
@@ -394,6 +398,10 @@ namespace Xceed.Wpf.AvalonDock.Controls
                 if (nextChildModel.DockWidth.IsStar)
                 {
                     nextChildModel.DockWidth = new GridLength(nextChildModel.DockWidth.Value * (nextChildActualSize.Width - delta) / nextChildActualSize.Width, GridUnitType.Star);
+                }
+                else if (nextChildModel.DockWidth.IsAuto)
+                {
+                    nextChildModel.DockWidth = new GridLength(nextChildActualSize.Width - delta, GridUnitType.Pixel);
                 }
                 else
                 {
@@ -406,6 +414,10 @@ namespace Xceed.Wpf.AvalonDock.Controls
                 {
                     prevChildModel.DockHeight = new GridLength(prevChildModel.DockHeight.Value * (prevChildActualSize.Height + delta) / prevChildActualSize.Height, GridUnitType.Star);
                 }
+                else if (prevChildModel.DockHeight.IsAuto)
+                {
+                    prevChildModel.DockHeight = new GridLength(prevChildActualSize.Height + delta, GridUnitType.Pixel);
+                }
                 else
                 {
                     prevChildModel.DockHeight = new GridLength(prevChildModel.DockHeight.Value + delta, GridUnitType.Pixel);
@@ -414,6 +426,10 @@ namespace Xceed.Wpf.AvalonDock.Controls
                 if (nextChildModel.DockHeight.IsStar)
                 {
                     nextChildModel.DockHeight = new GridLength(nextChildModel.DockHeight.Value * (nextChildActualSize.Height - delta) / nextChildActualSize.Height, GridUnitType.Star);
+                }
+                else if (nextChildModel.DockHeight.IsAuto)
+                {
+                    nextChildModel.DockHeight = new GridLength(nextChildActualSize.Height - delta, GridUnitType.Pixel);
                 }
                 else
                 {


### PR DESCRIPTION
AvalonDock crash bug: If you manually resize a panel with DockWidth set to auto then AvalonDock will crash with a negative width exception if you made it narrower. If you drag it bigger then when you release the mouse the width snaps back to being just the delta between the original width and the new width manually resized to.

This bug was fixed by checking if the DockWidth is auto when being resized, and if so then set the new size to the original ActualSize width plus the width delta.