### PR TITLE
AvalonDock Fixed some null reference exceptions

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorablePaneControl.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorablePaneControl.cs
@@ -62,7 +62,10 @@ namespace Xceed.Wpf.AvalonDock.Controls
 
         protected override void OnGotKeyboardFocus(System.Windows.Input.KeyboardFocusChangedEventArgs e)
         {
-            _model.SelectedContent.IsActive = true;
+            if (_model?.SelectedContent != null)
+            {
+                _model.SelectedContent.IsActive = true;
+            }
 
             base.OnGotKeyboardFocus(e);
         }

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutItem.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutItem.cs
@@ -204,9 +204,9 @@ namespace Xceed.Wpf.AvalonDock.Controls
                     _view = new ContentPresenter();
 
                     _view.SetBinding(ContentPresenter.ContentProperty, new Binding("Content") { Source = LayoutElement });
-                    _view.SetBinding( ContentPresenter.ContentTemplateProperty, new Binding( "LayoutItemTemplate" ) { Source = LayoutElement.Root.Manager } );
-                    _view.SetBinding( ContentPresenter.ContentTemplateSelectorProperty, new Binding( "LayoutItemTemplateSelector" ) { Source = LayoutElement.Root.Manager } );
-                    LayoutElement.Root.Manager.InternalAddLogicalChild( _view );
+                    _view.SetBinding(ContentPresenter.ContentTemplateProperty, new Binding("LayoutItemTemplate") { Source =  LayoutElement?.Root?.Manager});
+                    _view.SetBinding(ContentPresenter.ContentTemplateSelectorProperty, new Binding("LayoutItemTemplateSelector") { Source = LayoutElement?.Root?.Manager });
+                    LayoutElement?.Root?.Manager.InternalAddLogicalChild(_view);
                 }
 
                 return _view;


### PR DESCRIPTION
AvalonDock crash bug: During tear down phases of controls in an app there are times when AvalonDock gets in a state where it throws null reference exceptions. This fixes the areas that I've hit.