### PR TITLE
AvalonDock tabs undocking when changing tabs that are mixed size

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorableTabItem.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorableTabItem.cs
@@ -116,8 +116,11 @@ namespace Xceed.Wpf.AvalonDock.Controls
 
         #endregion
 
-        bool _isMouseDown = false;
-        static LayoutAnchorableTabItem _draggingItem = null;
+        private bool _isMouseDown = false;
+        private static LayoutAnchorableTabItem _draggingItem = null;
+        // There's an issue with panes resizing when selecting another tab, causing a
+        // mouse leave event to make the tab undock. This fixes that.
+        private static bool _cancelNextMouseLeave = false;
 
         internal static bool IsDraggingItem()
         {
@@ -131,6 +134,10 @@ namespace Xceed.Wpf.AvalonDock.Controls
         internal static void ResetDraggingItem()
         {
             _draggingItem = null;
+        }
+        internal static void CancelNextMouseLeave()
+        {
+            _cancelNextMouseLeave = true;
         }
 
         protected override void OnMouseLeftButtonDown(System.Windows.Input.MouseButtonEventArgs e)
@@ -150,6 +157,11 @@ namespace Xceed.Wpf.AvalonDock.Controls
                 _isMouseDown = false;
                 _draggingItem = null;
             }
+            else
+            {
+                _cancelNextMouseLeave = false;
+            }
+
         }
 
         protected override void OnMouseLeftButtonUp(System.Windows.Input.MouseButtonEventArgs e)
@@ -167,10 +179,18 @@ namespace Xceed.Wpf.AvalonDock.Controls
 
             if (_isMouseDown && e.LeftButton == MouseButtonState.Pressed)
             {
-                _draggingItem = this;
+                if (!_cancelNextMouseLeave)
+                {
+                    _draggingItem = this;
+                }
+                else
+                {
+                    _draggingItem = null;
+                }
             }
 
             _isMouseDown = false;
+            _cancelNextMouseLeave = false;
         }
 
         protected override void OnMouseEnter(MouseEventArgs e)

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Layout/LayoutContent.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Layout/LayoutContent.cs
@@ -127,6 +127,7 @@ namespace Xceed.Wpf.AvalonDock.Layout
                         parentSelector.SelectedContentIndex = _isSelected ? parentSelector.IndexOf(this) : -1;
                     OnIsSelectedChanged(oldValue, value);
                     RaisePropertyChanged("IsSelected");
+                    Controls.LayoutAnchorableTabItem.CancelNextMouseLeave();
                 }
             }
         }


### PR DESCRIPTION
AvalonDock behavior bug: If you have a panel that is auto sized, and it hosts tabs that are different widths, then the panel will grow and shrink as you change tabs. Unfortunately this can generate MouseLeave events on the tabs while the MouseLeftButton is down, and thus cause the tab panel to undock.

This fixes the issue by suppressing the next MouseLeave event when a panel IsSelected property is toggled. Suppression is cleared when the MouseMove event fires or when the MouseLeave event is triggered.