### PR TITLE
AvalonDock Made ContentID Bindable in LayoutContent.cs

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Layout/LayoutContent.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Layout/LayoutContent.cs
@@ -84,25 +84,31 @@ namespace Xceed.Wpf.AvalonDock.Layout
 
         #region ContentId
 
-        private string _contentId = null;
+        //Added to make ContentId bindable
+        public static DependencyProperty ContentIdProperty =
+            DependencyProperty.Register(nameof(ContentId),
+              typeof(string), typeof(LayoutContent), new FrameworkPropertyMetadata(null, (s, e) =>
+               {
+                  (s as LayoutContent)?.RaisePropertyChanged(nameof(ContentId));
+              }));
+
         public string ContentId
         {
-            get 
+            get
             {
-                if (_contentId == null)
-                { 
+                if (GetValue(ContentIdProperty) == null)
+                {
                     var contentAsControl = _content as FrameworkElement;
                     if (contentAsControl != null && !string.IsNullOrWhiteSpace(contentAsControl.Name))
                         return contentAsControl.Name;
                 }
-                return _contentId; 
+                return (string)GetValue(ContentIdProperty);
             }
             set
             {
-                if (_contentId != value)
+                if (!String.Equals(GetValue(ContentIdProperty) as string, value))
                 {
-                    _contentId = value;
-                    RaisePropertyChanged("ContentId");
+                    SetValue(ContentIdProperty, value);
                 }
             }
         }


### PR DESCRIPTION
AvalonDock desired behavior: ContentId in LayoutContent.cs is a user set string, as such it should be a DependencyProperty so a binding can be set from the view model when using Model-View-View-Model programming patterns.

A colleague of mine changed the code so that it is now a DependencyProperty.