### PR TITLE
Fixed null reference when databound mask is nulled

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/MaskedTextBox/Implementation/MaskedTextBox.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/MaskedTextBox/Implementation/MaskedTextBox.cs
@@ -1441,7 +1441,7 @@ namespace Xceed.Wpf.Toolkit
 
     internal override bool GetIsEditTextEmpty()
     {
-      return ( this.MaskedTextProvider.AssignedEditPositionCount == 0 );
+      return MaskedTextProvider != null && (MaskedTextProvider.AssignedEditPositionCount == 0 );
     }
 
     #endregion INTERNAL PROPERTIES


### PR DESCRIPTION
Fixes: #1179 

Before fix forcibly nulling the datacontext of the Masked text box causes a null reference to be thrown.

After fix - nulling data context doesn't throw an exception. Mask is lost from textbox as it doesn't have anything bound to it.