### PR TITLE
Made fixed size behavior in OnFixChildrenDockLengths optional.

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorablePaneGroupControl.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorablePaneGroupControl.cs
@@ -43,7 +43,7 @@ namespace Xceed.Wpf.AvalonDock.Controls
                 for (int i = 0; i < _model.Children.Count; i++)
                 {
                     var childModel = _model.Children[i] as ILayoutPositionableElement;
-                    if (!childModel.DockWidth.IsStar)
+                    if (childModel.ForceFixedDockSize && !childModel.DockWidth.IsStar)
                     {
                         childModel.DockWidth = new GridLength(1.0, GridUnitType.Star);
                     }
@@ -54,7 +54,7 @@ namespace Xceed.Wpf.AvalonDock.Controls
                 for (int i = 0; i < _model.Children.Count; i++)
                 {
                     var childModel = _model.Children[i] as ILayoutPositionableElement;
-                    if (!childModel.DockHeight.IsStar)
+                    if (childModel.ForceFixedDockSize && !childModel.DockHeight.IsStar)
                     {
                         childModel.DockHeight = new GridLength(1.0, GridUnitType.Star);
                     }

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutDocumentPaneGroupControl.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutDocumentPaneGroupControl.cs
@@ -42,7 +42,7 @@ namespace Xceed.Wpf.AvalonDock.Controls
                 for (int i = 0; i < _model.Children.Count; i++)
                 {
                     var childModel = _model.Children[i] as ILayoutPositionableElement;
-                    if (!childModel.DockWidth.IsStar)
+                    if (childModel.ForceFixedDockSize && !childModel.DockWidth.IsStar)
                     {
                         childModel.DockWidth = new GridLength(1.0, GridUnitType.Star);
                     }
@@ -53,7 +53,7 @@ namespace Xceed.Wpf.AvalonDock.Controls
                 for (int i = 0; i < _model.Children.Count; i++)
                 {
                     var childModel = _model.Children[i] as ILayoutPositionableElement;
-                    if (!childModel.DockHeight.IsStar)
+                    if (childModel.ForceFixedDockSize && !childModel.DockHeight.IsStar)
                     {
                         childModel.DockHeight = new GridLength(1.0, GridUnitType.Star);
                     }

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutPanelControl.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutPanelControl.cs
@@ -52,24 +52,24 @@ namespace Xceed.Wpf.AvalonDock.Controls
                         var childContainerModel = _model.Children[i] as ILayoutContainer;
                         var childPositionableModel = _model.Children[i] as ILayoutPositionableElement;
 
-                        if (childContainerModel != null &&
-                            (childContainerModel.IsOfType<LayoutDocumentPane, LayoutDocumentPaneGroup>() ||
-                             childContainerModel.ContainsChildOfType<LayoutDocumentPane, LayoutDocumentPaneGroup>()))
+                        if (childPositionableModel.ForceFixedDockSize) 
                         {
-                            childPositionableModel.DockWidth = new GridLength(1.0, GridUnitType.Star);
-                        }
-                        else if (childPositionableModel != null && childPositionableModel.DockWidth.IsStar)
-                        {
-                            var childPositionableModelWidthActualSize = childPositionableModel as ILayoutPositionableElementWithActualSize;
+                            if (childContainerModel != null &&
+                                (childContainerModel.IsOfType<LayoutDocumentPane, LayoutDocumentPaneGroup>() ||
+                                 childContainerModel.ContainsChildOfType<LayoutDocumentPane, LayoutDocumentPaneGroup>())) {
+                                childPositionableModel.DockWidth = new GridLength(1.0, GridUnitType.Star);
+                            } else if (childPositionableModel != null && childPositionableModel.DockWidth.IsStar) {
+                                var childPositionableModelWidthActualSize = childPositionableModel as ILayoutPositionableElementWithActualSize;
 
-                            var widthToSet = Math.Max(childPositionableModelWidthActualSize.ActualWidth, childPositionableModel.DockMinWidth);
+                                var widthToSet = Math.Max(childPositionableModelWidthActualSize.ActualWidth, childPositionableModel.DockMinWidth);
 
-                            widthToSet = Math.Min(widthToSet, ActualWidth / 2.0);
-                            widthToSet = Math.Max(widthToSet, childPositionableModel.DockMinWidth);
+                                widthToSet = Math.Min(widthToSet, ActualWidth / 2.0);
+                                widthToSet = Math.Max(widthToSet, childPositionableModel.DockMinWidth);
 
-                            childPositionableModel.DockWidth = new GridLength(
-                                widthToSet,
-                                GridUnitType.Pixel);
+                                childPositionableModel.DockWidth = new GridLength(
+                                    widthToSet,
+                                    GridUnitType.Pixel);
+                            }
                         }
                     }
                 }
@@ -78,7 +78,7 @@ namespace Xceed.Wpf.AvalonDock.Controls
                     for (int i = 0; i < _model.Children.Count; i++)
                     {
                         var childPositionableModel = _model.Children[i] as ILayoutPositionableElement;
-                        if (!childPositionableModel.DockWidth.IsStar)
+                        if (childPositionableModel.ForceFixedDockSize && !childPositionableModel.DockWidth.IsStar)
                         {
                             childPositionableModel.DockWidth = new GridLength(1.0, GridUnitType.Star);
                         }
@@ -94,21 +94,21 @@ namespace Xceed.Wpf.AvalonDock.Controls
                         var childContainerModel = _model.Children[i] as ILayoutContainer;
                         var childPositionableModel = _model.Children[i] as ILayoutPositionableElement;
 
-                        if (childContainerModel != null &&
-                            (childContainerModel.IsOfType<LayoutDocumentPane, LayoutDocumentPaneGroup>() ||
-                             childContainerModel.ContainsChildOfType<LayoutDocumentPane, LayoutDocumentPaneGroup>()))
+                        if (childPositionableModel.ForceFixedDockSize) 
                         {
-                            childPositionableModel.DockHeight = new GridLength(1.0, GridUnitType.Star);
-                        }
-                        else if (childPositionableModel != null && childPositionableModel.DockHeight.IsStar)
-                        {
-                            var childPositionableModelWidthActualSize = childPositionableModel as ILayoutPositionableElementWithActualSize;
+                            if (childContainerModel != null &&
+                                (childContainerModel.IsOfType<LayoutDocumentPane, LayoutDocumentPaneGroup>() ||
+                                 childContainerModel.ContainsChildOfType<LayoutDocumentPane, LayoutDocumentPaneGroup>())) {
+                                childPositionableModel.DockHeight = new GridLength(1.0, GridUnitType.Star);
+                            } else if (childPositionableModel != null && childPositionableModel.DockHeight.IsStar) {
+                                var childPositionableModelWidthActualSize = childPositionableModel as ILayoutPositionableElementWithActualSize;
 
-                            var heightToSet = Math.Max(childPositionableModelWidthActualSize.ActualHeight, childPositionableModel.DockMinHeight);
-                            heightToSet = Math.Min(heightToSet, ActualHeight / 2.0);
-                            heightToSet = Math.Max(heightToSet, childPositionableModel.DockMinHeight);
+                                var heightToSet = Math.Max(childPositionableModelWidthActualSize.ActualHeight, childPositionableModel.DockMinHeight);
+                                heightToSet = Math.Min(heightToSet, ActualHeight / 2.0);
+                                heightToSet = Math.Max(heightToSet, childPositionableModel.DockMinHeight);
 
-                            childPositionableModel.DockHeight = new GridLength(heightToSet, GridUnitType.Pixel);
+                                childPositionableModel.DockHeight = new GridLength(heightToSet, GridUnitType.Pixel);
+                            }
                         }
                     }
                 }
@@ -117,7 +117,7 @@ namespace Xceed.Wpf.AvalonDock.Controls
                     for (int i = 0; i < _model.Children.Count; i++)
                     {
                         var childPositionableModel = _model.Children[i] as ILayoutPositionableElement;
-                        if (!childPositionableModel.DockHeight.IsStar)
+                        if (childPositionableModel.ForceFixedDockSize && !childPositionableModel.DockHeight.IsStar)
                         {
                             childPositionableModel.DockHeight = new GridLength(1.0, GridUnitType.Star);
                         }

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Layout/ILayoutPositionableElement.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Layout/ILayoutPositionableElement.cs
@@ -42,6 +42,7 @@ namespace Xceed.Wpf.AvalonDock.Layout
         bool AllowDuplicateContent { get; set; }
 
         bool IsVisible { get; }
+        bool ForceFixedDockSize { get; }
     }
 
 

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Layout/LayoutPositionableGroup.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Layout/LayoutPositionableGroup.cs
@@ -76,7 +76,29 @@ namespace Xceed.Wpf.AvalonDock.Layout
         }
 
         protected virtual void OnDockHeightChanged()
-        { 
+        {
+
+        }
+
+        bool _forceFixedDockSize;
+        public bool ForceFixedDockSize
+        {
+            get {
+                return _forceFixedDockSize;
+            }
+            set {
+                if (ForceFixedDockSize != value) {
+                    RaisePropertyChanging("HasFixedDockSize");
+                    _forceFixedDockSize = value;
+                    RaisePropertyChanging("HasFixedDockSize");
+
+                    OnHasFixedDockSizeChanged();
+                }
+            }
+        }
+
+        protected virtual void OnHasFixedDockSizeChanged()
+        {
 
         }
 


### PR DESCRIPTION
See my post discussing a problem that this resolves:
https://stackoverflow.com/questions/46499858/xceed-avalondock-3-2-dockwidth-height-has-no-effect