### PR TITLE
AvalonDock fixed misspelling when serializing DockMinWidth/DockMinHei…

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Layout/LayoutPositionableGroup.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Layout/LayoutPositionableGroup.cs
@@ -301,7 +301,7 @@ namespace Xceed.Wpf.AvalonDock.Layout
                 writer.WriteAttributeString("DockHeight", _gridLengthConverter.ConvertToInvariantString(DockHeight));
 
             if (DockMinWidth != 25.0)
-                writer.WriteAttributeString("DocMinWidth", DockMinWidth.ToString(CultureInfo.InvariantCulture));
+                writer.WriteAttributeString("DockMinWidth", DockMinWidth.ToString(CultureInfo.InvariantCulture));
             if (DockMinHeight != 25.0)
                 writer.WriteAttributeString("DockMinHeight", DockMinHeight.ToString(CultureInfo.InvariantCulture));
 
@@ -327,9 +327,9 @@ namespace Xceed.Wpf.AvalonDock.Layout
             if (reader.MoveToAttribute("DockHeight"))
                 _dockHeight = (GridLength)_gridLengthConverter.ConvertFromInvariantString(reader.Value);
 
-            if (reader.MoveToAttribute("DocMinWidth"))
+            if (reader.MoveToAttribute("DockMinWidth"))
                 _dockMinWidth = double.Parse(reader.Value, CultureInfo.InvariantCulture);
-            if (reader.MoveToAttribute("DocMinHeight"))
+            if (reader.MoveToAttribute("DockMinHeight"))
                 _dockMinHeight = double.Parse(reader.Value, CultureInfo.InvariantCulture);
 
             if (reader.MoveToAttribute("FloatingWidth"))


### PR DESCRIPTION
Currently the DockMinHeight property can't be deserialized.