### PR TITLE
Fixing a small issue where a Mask starting with > or < is not accepti…

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/MaskedTextBox/Implementation/MaskedTextBox.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/MaskedTextBox/Implementation/MaskedTextBox.cs
@@ -1907,14 +1907,6 @@ namespace Xceed.Wpf.Toolkit
 
     private string GetFormattedString( MaskedTextProvider provider, string text )
     {
-      if( provider.Mask.StartsWith( ">" ) )
-        return text.ToUpper();
-      if( provider.Mask.StartsWith( "<" ) )
-        return text.ToLower();
-
-      //System.Diagnostics.Debug.Assert( provider.EditPositionCount > 0 );
-
-
       bool includePrompt = ( this.IsReadOnly ) ? false : ( !this.HidePromptOnLeave || this.IsFocused );
 
       string displayString = provider.ToString( false, includePrompt, true, 0, m_maskedTextProvider.Length );

--- a/ExtendedWPFToolkitSolution_35/Src/Xceed.Wpf.Toolkit/MaskedTextBox/Implementation/MaskedTextBox.cs
+++ b/ExtendedWPFToolkitSolution_35/Src/Xceed.Wpf.Toolkit/MaskedTextBox/Implementation/MaskedTextBox.cs
@@ -1907,14 +1907,6 @@ namespace Xceed.Wpf.Toolkit
 
     private string GetFormattedString( MaskedTextProvider provider, string text )
     {
-      if( provider.Mask.StartsWith( ">" ) )
-        return text.ToUpper();
-      if( provider.Mask.StartsWith( "<" ) )
-        return text.ToLower();
-
-      //System.Diagnostics.Debug.Assert( provider.EditPositionCount > 0 );
-
-
       bool includePrompt = ( this.IsReadOnly ) ? false : ( !this.HidePromptOnLeave || this.IsFocused );
 
       string displayString = provider.ToString( false, includePrompt, true, 0, m_maskedTextProvider.Length );


### PR DESCRIPTION
This pull request is for attempting to fix [issue 1316](https://github.com/xceedsoftware/wpftoolkit/issues/1316). I think the removed lines are causing the control to not to accept any input if the mask starts with **<** or **>** . Also the MaskedTextProvider handles the **>** **<** symbols already. 