### PR TITLE
Update zh-Hans translation

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Properties/Resources.zh-Hans.resx
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Properties/Resources.zh-Hans.resx
@@ -142,16 +142,16 @@
     <value>隐藏</value>
   </data>
   <data name="Document_BtnPinned_Hint" xml:space="preserve">
-    <value>切換引腳狀態</value>
+    <value>切换固定状态</value>
   </data>
   <data name="Document_Close" xml:space="preserve">
     <value>关闭</value>
   </data>
   <data name="Document_CloseAll" xml:space="preserve">
-    <value>關閉所有</value>
+    <value>关闭所有</value>
   </data>
   <data name="Document_CloseAllButThis" xml:space="preserve">
-    <value>留此，关闭其他</value>
+    <value>除此之外全部关闭</value>
   </data>
   <data name="Document_CxMenu_Hint" xml:space="preserve">
     <value>窗口位置</value>
@@ -178,6 +178,6 @@
     <value>最大化</value>
   </data>
   <data name="Window_Restore" xml:space="preserve">
-    <value>恢复</value>
+    <value>还原</value>
   </data>
 </root>


### PR DESCRIPTION
Updated four string resources of zh-Hans.

* Document_BtnPinned_Hint
The original text "切換引腳狀態" is not zh-Hans but zh-Hant. The new text "切换固定状态" is the same as one in Visual Studio zh-Hans.

* Document_CloseAll
The new text is identical as the original one except zh-Hant characters are changed to zh-Hans characters.

* Document_CloseAllButThis
The new text looks better and it is the same as the one in Visual Studio.

* Window_Restore
Chinese version of Windows says "还原" instead of "恢复".