### PR TITLE
Update ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/DropDownButto…

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/DropDownButton/Implementation/DropDownButton.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/DropDownButton/Implementation/DropDownButton.cs
@@ -375,7 +375,8 @@ namespace Xceed.Wpf.Toolkit
 
     private void OnMouseDownOutsideCapturedElement( object sender, MouseButtonEventArgs e )
     {
-      CloseDropDown( true );
+      if( !IsMouseOver )
+        CloseDropDown( true );
     }
 
     private void DropDownButton_Click( object sender, RoutedEventArgs e )


### PR DESCRIPTION
…n/Implementation/DropDownButton.cs

Checking if the mouse is outside the bounds of the DropDownButton when the PreviewMouseDownOutsideCapturedElement event tunnels through it to prevent the DropDownButton's Popup from closing if the event is caused by a child Popup

fixes #1400 