### PR TITLE
initialization of _model was missing in one of the two constructor.

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -57,6 +57,7 @@ namespace Xceed.Wpf.AvalonDock.Controls
     internal LayoutAnchorableFloatingWindowControl( LayoutAnchorableFloatingWindow model)
         : base( model, false )
     {
+        _model = model;
     }
 
     #endregion


### PR DESCRIPTION
see https://github.com/xceedsoftware/wpftoolkit/issues/1442. This resolves the issue.