### PR TITLE
Fixes a bug of function 'SetBlackOutDates' in DateTimePicker

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/DateTimePicker/Implementation/DateTimePicker.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/DateTimePicker/Implementation/DateTimePicker.cs
@@ -455,12 +455,12 @@ namespace Xceed.Wpf.Toolkit
       {
         _calendar.BlackoutDates.Clear();
 
-        if( ( this.Minimum != null ) && this.Minimum.HasValue && ( this.Minimum.Value != DateTime.MinValue ) )
+        if( Minimum != null && ( this.Minimum.Value.Date != DateTime.MinValue.Date ) )
         {
           DateTime minDate = this.Minimum.Value;
           _calendar.BlackoutDates.Add( new CalendarDateRange( DateTime.MinValue, minDate.AddDays( -1 ) ) );
         }
-        if( ( this.Maximum != null ) && this.Maximum.HasValue && ( this.Maximum.Value != DateTime.MaxValue ) )
+        if( ( this.Maximum != null ) && ( this.Maximum.Value.Date != DateTime.MaxValue.Date ) )
         {
           DateTime maxDate = this.Maximum.Value;
           _calendar.BlackoutDates.Add( new CalendarDateRange( maxDate.AddDays( 1 ), DateTime.MaxValue ) );


### PR DESCRIPTION
If set Maximum to DateTime.MaxValue (9999/12/31 23:59), it is ok, but set it to 9999/12/31 22:00 it will be crashed, because the codes in SetBlackOutDates:
`maxDate.AddDays( 1 )`
Minimum is the same.