### PR TITLE
Hotfix/CategoryOrderAttribute fixes

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Attributes/CategoryOrderAttribute.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Attributes/CategoryOrderAttribute.cs
@@ -55,6 +55,13 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid.Attributes
 
     #endregion
 
+    #region TypeId
+
+    public override object TypeId
+      => CategoryValue;
+
+    #endregion TypeId
+
     #endregion
 
     #region constructor
@@ -73,4 +80,3 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid.Attributes
     #endregion
   }
 }
-

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelper.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelper.cs
@@ -133,36 +133,20 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
       return propertyItem;
     }
 
-    private int GetCategoryOrder( object categoryValue )
+    private int GetCategoryOrder(object categoryValue)
     {
-      Debug.Assert( SelectedObject != null );
+      Debug.Assert(SelectedObject != null);
 
-      if( categoryValue == null )
+      if (categoryValue == null)
         return int.MaxValue;
 
-      int order = int.MaxValue;
-        object selectedObject = SelectedObject;
-        CategoryOrderAttribute[] orderAttributes = ( selectedObject != null )
-          ? ( CategoryOrderAttribute[] )selectedObject.GetType().GetCustomAttributes( typeof( CategoryOrderAttribute ), true )
-          : new CategoryOrderAttribute[ 0 ];
+      object selectedObject = SelectedObject;
 
-        var orderAttribute = orderAttributes
-          .FirstOrDefault( ( a ) => object.Equals( a.CategoryValue, categoryValue ) );
+      var orderAttribute = TypeDescriptor.GetAttributes(selectedObject)
+        .OfType<CategoryOrderAttribute>()
+        .FirstOrDefault(a => Equals(a.CategoryValue, categoryValue));
 
-        if( orderAttribute != null )
-        {
-          order = orderAttribute.Order;
-        }
-
-      return order;
+      return orderAttribute?.Order ?? int.MaxValue;
     }
-
-
-
-
-
-
-
-
   }
 }


### PR DESCRIPTION
This corrects a missing TypeId from the CategoryOrderAttribute as well as updates the logic to get the order from that attribute for those added at runtime via TypeDescriptor.AddAttributes.