### PR TITLE
Fixed constructors of LayoutAnchorableFloatingWindowControl and Layou…

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutAnchorableFloatingWindowControl.cs
@@ -55,7 +55,7 @@ namespace Xceed.Wpf.AvalonDock.Controls
     }
 
     internal LayoutAnchorableFloatingWindowControl( LayoutAnchorableFloatingWindow model)
-        : base( model, false )
+        : this( model, false )
     {
     }
 

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Controls/LayoutDocumentFloatingWindowControl.cs
@@ -45,7 +45,7 @@ namespace Xceed.Wpf.AvalonDock.Controls
     }
 
     internal LayoutDocumentFloatingWindowControl( LayoutDocumentFloatingWindow model )
-        : base( model, false )
+        : this( model, false )
     {
     }
 


### PR DESCRIPTION
It seems to me that in both LayoutAnchorableFloatingWindowControl  and LayoutDocumentFloatingWindowControl classes the constructors with single parameter should call the other constructor of the respective class instead of the base class as otherwise at least _model field won't get initialized and there are problems afterwards.