### PR TITLE
Use TextBox instead of TextBlock for displaying read only property

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Editors/ReadOnlyTextBoxEditor.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Editors/ReadOnlyTextBoxEditor.cs
@@ -1,0 +1,28 @@
+﻿using System.Windows;
+using System.Windows.Controls;
+using Xceed.Wpf.Toolkit.PropertyGrid.Editors;
+
+namespace Xceed.Wpf.Toolkit.PropertyGrid.Editors
+{
+    public class ReadOnlyTextBoxEditor : TypeEditor<TextBox>
+    {
+        protected override TextBox CreateEditor()
+        {
+            return new PropertyGridReadOnlyTextBoxEditor();
+        }
+
+        protected override void SetValueDependencyProperty()
+        {
+            ValueProperty = TextBox.TextProperty;
+        }
+
+    }
+
+    public class PropertyGridReadOnlyTextBoxEditor : TextBox
+    {
+        static PropertyGridReadOnlyTextBoxEditor()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(PropertyGridReadOnlyTextBoxEditor), new FrameworkPropertyMetadata(typeof(PropertyGridReadOnlyTextBoxEditor)));
+        }
+    }
+}

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Editors/TextBlockEditor.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Editors/TextBlockEditor.cs
@@ -16,9 +16,11 @@
 
 using System.Windows.Controls;
 using System.Windows;
+using System;
 
 namespace Xceed.Wpf.Toolkit.PropertyGrid.Editors
 {
+  [Obsolete("Use ReadOnlyTextBoxEditor instead which uses a TextBox control for displaying content since TextBlock doesn't support ControlTemplate for customization")]
   public class TextBlockEditor : TypeEditor<TextBlock>
   {
     protected override TextBlock CreateEditor()

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelperBase.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelperBase.cs
@@ -469,7 +469,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
       if( editorElement == null )
       {
         if( pd.IsReadOnly )
-          editor = new TextBlockEditor();
+          editor = new ReadOnlyTextBoxEditor();
 
         // Fallback: Use a default type editor.
         if( editor == null )

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/PropertyGridUtilities.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/PropertyGridUtilities.cs
@@ -132,7 +132,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
             // Otherwise, return a TextBlock editor since no valid editor exists.
             editor = (typeConverter != null && typeConverter.CanConvertFrom( typeof( string ) ))
               ? (ITypeEditor)new TextBoxEditor()
-              : (ITypeEditor)new TextBlockEditor();
+              : (ITypeEditor)new ReadOnlyTextBoxEditor();
           }
         }
       }

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Themes/Aero2.NormalColor.xaml
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Themes/Aero2.NormalColor.xaml
@@ -280,7 +280,19 @@
             Value="Gray" />
   </Style>
 
-  <!-- PropertyGrid MaskedTextBox Editors -->
+    <!-- PropertyGrid ReadOnly TextBox Editor -->
+    <Style TargetType="{x:Type editor:PropertyGridReadOnlyTextBoxEditor}" BasedOn="{StaticResource {x:Type TextBox}}">
+        <Setter Property="Foreground" Value="Gray" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate>
+                    <TextBlock TextTrimming="CharacterEllipsis" Margin="5,0,0,0" Text="{Binding Path=Value}"></TextBlock>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- PropertyGrid MaskedTextBox Editors -->
   <Style TargetType="{x:Type editor:PropertyGridEditorMaskedTextBox}"
          BasedOn="{StaticResource {x:Type TextBox}}">
   </Style>

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Themes/Generic.xaml
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Themes/Generic.xaml
@@ -286,7 +286,20 @@
             Value="Gray" />
   </Style>
 
-  <!-- PropertyGrid MaskedTextBox Editors -->
+    <!-- PropertyGrid ReadOnly TextBox Editor -->
+   <Style TargetType="{x:Type editor:PropertyGridReadOnlyTextBoxEditor}" BasedOn="{StaticResource {x:Type TextBox}}">
+       <Setter Property="Foreground" Value="Gray" />
+       <Setter Property="Template">
+           <Setter.Value>
+               <ControlTemplate>
+                   <TextBlock TextTrimming="CharacterEllipsis" Margin="5,0,0,0" Text="{Binding Path=Value}"></TextBlock>
+               </ControlTemplate>
+           </Setter.Value>
+       </Setter>
+   </Style>
+
+
+    <!-- PropertyGrid MaskedTextBox Editors -->
   <Style TargetType="{x:Type editor:PropertyGridEditorMaskedTextBox}"
          BasedOn="{StaticResource {x:Type TextBox}}">
   </Style>

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/Xceed.Wpf.Toolkit.csproj
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/Xceed.Wpf.Toolkit.csproj
@@ -441,6 +441,7 @@
     <Compile Include="PropertyGrid\Implementation\Converters\IsDefaultCategoryConverter.cs" />
     <Compile Include="PropertyGrid\Implementation\Converters\IsStringEmptyConverter.cs" />
     <Compile Include="PropertyGrid\Implementation\Editors\CollectionEditor.cs" />
+    <Compile Include="PropertyGrid\Implementation\Editors\ReadOnlyTextBoxEditor.cs" />
     <Compile Include="PropertyGrid\Implementation\Editors\SourceComboBoxEditor.cs" />
     <Compile Include="PropertyGrid\Implementation\TrimmedTextBlock.cs" />
     <Compile Include="Core\Converters\WindowContentBorderMarginConverter.cs" />


### PR DESCRIPTION
**Issue Description**
1. TextBlockEditor : TypeEditor<TextBlock> is used in PropertyGrid for displaying readonly properties.
However, TextBlock control in WPF doesn't allow to override it's Template using a style.
2. Margin is set to (5,0,0,0) from inside SetControlProperties() of TextBlockEditor which takes precedence over any margin applied from style.

**Changes**
1. Created a new ReadOnlyTextBoxEditor which uses TextBox to display readonly property
2. The default style overrides control template of textbox such that it uses a TextBlock with  TextTrimming="CharacterEllipsis" and Margin="5,0,0,0" similar to what TextBlockEditor was using.
3. Updated TextBlockEditor initialization at different places to intialize ReadOnlyTextBoxEditor instead.

**Impact on existing users **
1. Those using default styles won't notice any difference in UI since TextBlock will be used to display readonly property 
2. Those who have customized style for TextBlockEditor will have to create a new style for ReadOnlyTextBoxEditor instead. 

** Benefit **
Users will now be able to provide a custom control template in styles for displaying their readonly property which was not possible before with a TextBlock.