### PR TITLE
Fixed LayoutRoot implementation of IXmlSerializable.ReadXml to read the end element.

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Layout/LayoutRoot.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Layout/LayoutRoot.cs
@@ -1,11 +1,11 @@
 ﻿/*************************************************************************************
-
+   
    Toolkit for WPF
 
    Copyright (C) 2007-2018 Xceed Software Inc.
 
    This program is provided to you under the terms of the Microsoft Public
-   License (Ms-PL) as published at http://wpftoolkit.codeplex.com/license
+   License (Ms-PL) as published at http://wpftoolkit.codeplex.com/license 
 
    For more features, controls, and fast professional support,
    pick up the Plus Edition at https://xceed.com/xceed-toolkit-plus-for-wpf/

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Layout/LayoutRoot.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock/Layout/LayoutRoot.cs
@@ -1,11 +1,11 @@
 ﻿/*************************************************************************************
-   
+
    Toolkit for WPF
 
    Copyright (C) 2007-2018 Xceed Software Inc.
 
    This program is provided to you under the terms of the Microsoft Public
-   License (Ms-PL) as published at http://wpftoolkit.codeplex.com/license 
+   License (Ms-PL) as published at http://wpftoolkit.codeplex.com/license
 
    For more features, controls, and fast professional support,
    pick up the Plus Edition at https://xceed.com/xceed-toolkit-plus-for-wpf/
@@ -672,6 +672,9 @@ namespace Xceed.Wpf.AvalonDock.Layout
       {
         this.Hidden.Add( ( LayoutAnchorable )hiddenObject );
       }
+
+      //Read the closing end element of LayoutRoot
+      reader.ReadEndElement();
     }
 
     public void WriteXml( XmlWriter writer )


### PR DESCRIPTION
Implementations of IXmlSerializable.ReadXml are required to read the entire element from beginning to end, including all of its contents. Prior to this change it would not read the end element from the reader. This would cause issues if the LayoutRoot was being serialized as part of a parent object's xml serialization as the XmlReader would be left on an unexpected element.