### PR TITLE
Add support for `ICloneable` to the `CollectionControl`

### DIFF
--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit.LiveExplorer/CodeFiles/PropertyGridDefaultEditorsView.xaml.cs.txt
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit.LiveExplorer/CodeFiles/PropertyGridDefaultEditorsView.xaml.cs.txt
@@ -167,9 +167,15 @@ namespace Xceed.Wpf.Toolkit.LiveExplorer.Samples.PropertyGrid.Views
       public Person Person { get; set; }
     }
 
-    public class Person
+    public class Person : ICloneable
     {
+      [ReadOnly(true)]
+      public Guid UniqueID { get; set; } = Guid.NewGuid();
       public string Name { get; set; }
+      public object Clone()
+      {
+        return new Person { Name = Name };
+      }
     }
   }
 }

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit.LiveExplorer/Samples/PropertyGrid/Views/PropertyGridDefaultEditorsView.xaml.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit.LiveExplorer/Samples/PropertyGrid/Views/PropertyGridDefaultEditorsView.xaml.cs
@@ -167,9 +167,15 @@ namespace Xceed.Wpf.Toolkit.LiveExplorer.Samples.PropertyGrid.Views
       public Person Person { get; set; }
     }
 
-    public class Person
+    public class Person : ICloneable
     {
+      [ReadOnly(true)]
+      public Guid UniqueID { get; set; } = Guid.NewGuid();
       public string Name { get; set; }
+      public object Clone()
+      {
+        return new Person { Name = Name };
+      }
     }
   }
 }

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/CollectionControl/Implementation/CollectionControl.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/CollectionControl/Implementation/CollectionControl.cs
@@ -539,20 +539,28 @@ namespace Xceed.Wpf.Toolkit
 
       var baseItem = e.Parameter;
       var newItemType = baseItem.GetType();
-      var newItem = this.CreateNewItem( newItemType );
-
-      var type = newItemType;
-      while( type != null )
+      if (typeof(ICloneable).IsAssignableFrom(newItemType))
       {
-        var baseProperties = type.GetFields( BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance );
-        foreach( var prop in baseProperties )
-        {
-          prop.SetValue( newItem, prop.GetValue( baseItem ) );
-        }
-        type = type.BaseType;
+          return ((ICloneable) baseItem).Clone();
       }
+      else
+      {
+          var newItem = this.CreateNewItem(newItemType);
 
-      return newItem;
+          var type = newItemType;
+          while (type != null)
+          {
+              var baseProperties = type.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+              foreach (var prop in baseProperties)
+              {
+                  prop.SetValue(newItem, prop.GetValue(baseItem));
+              }
+
+              type = type.BaseType;
+          }
+
+          return newItem;
+      }
     }
 
     private void MoveDown( object sender, ExecutedRoutedEventArgs e )


### PR DESCRIPTION
As per issue #1676, this modifies the `Duplicate` method of the `CollectionControl` to use `ICloneable` to perform the duplication when its available. If it is not available it uses the original method.
